### PR TITLE
Account for spaces in a TV show name when searching for TV shows

### DIFF
--- a/library.py
+++ b/library.py
@@ -38,7 +38,7 @@ class Library(object):
 
 
     def findAll(self, name, type=None):
-        query = "/search?query=%s" % name
+        query = "/search?query=%s" % name.replace(" ", "%20")
         element = self.server.query(query)
         
         items = []


### PR DESCRIPTION
Refined findAll method. Replaces a space in a TV show's name with "%20".
