### PR TITLE
Movies and episodes no longer returns as unwatched if watched more than once

### DIFF
--- a/episode.py
+++ b/episode.py
@@ -8,7 +8,7 @@ class Episode(object):
         self.summary = element.attrib['summary']
         self.index = int(element.attrib['index'])
         
-        self.viewed = ('viewCount' in element.attrib) and (element.attrib['viewCount'] == '1')
+        self.viewed = ('viewCount' in element.attrib) and (element.attrib['viewCount'] >= '1')
         self.offset = int(element.attrib['viewOffset']) if 'viewOffset' in element.attrib else 0
         self.file = element.find('.Media/Part').attrib['file']
     

--- a/movie.py
+++ b/movie.py
@@ -9,7 +9,7 @@ class Movie(object):
         self.title = element.attrib['title']
         self.year = int(element.attrib['year'])
         self.summary = element.attrib['summary']
-        self.viewed = ('viewCount' in element.attrib) and (element.attrib['viewCount'] == '1')
+        self.viewed = ('viewCount' in element.attrib) and (element.attrib['viewCount'] >= '1')
         self.offset = int(element.attrib['viewOffset']) if 'viewOffset' in element.attrib else 0
         self.file = element.find('.Media/Part').attrib['file']
     


### PR DESCRIPTION
If the viewCount of a movie or episode was greater than 1 it was returned as unwatched.
