### PR TITLE
Fix for getNextUnwatchedEpisode()

### DIFF
--- a/episode.py
+++ b/episode.py
@@ -19,3 +19,6 @@ class Episode(Video):
     def __repr__(self):
         return "<Episode: %s - %dx%.2d - %s>" % (self.show_title, self.season, self.episode, self.title)
 
+    def __eq__(self, other_episode):
+        return self.__repr__() == other_episode.__repr__()
+

--- a/episode.py
+++ b/episode.py
@@ -8,12 +8,13 @@ class Episode(Video):
         self.type = 'episode'
         try:
             self.index = int(element.attrib['index'])
+            self.season = int(element.attrib['parentIndex'])
         except KeyError as e:
             print "Missing key in element: ", e.message
 
     def __str__(self):
-        return "<Episode: %s (%d)>" % (self.title, self.index)
+        return "<Episode: %s (%dx%.2d)>" % (self.title, self.season, self.index)
 
     def __repr__(self):
-        return "<Episode: %s (%d)>" % (self.title, self.index)
+        return "<Episode: %s (%dx%.2d)>" % (self.title, self.season, self.index)
 

--- a/episode.py
+++ b/episode.py
@@ -7,14 +7,15 @@ class Episode(Video):
 
         self.type = 'episode'
         try:
-            self.index = int(element.attrib['index'])
+            self.episode = int(element.attrib['index'])
             self.season = int(element.attrib['parentIndex'])
+            self.show_title = element.attrib['grandparentTitle']
         except KeyError as e:
             print "Missing key in element: ", e.message
 
     def __str__(self):
-        return "<Episode: %s (%dx%.2d)>" % (self.title, self.season, self.index)
+        return "<Episode: %s - %dx%.2d - %s>" % (self.show_title, self.season, self.episode, self.title)
 
     def __repr__(self):
-        return "<Episode: %s (%dx%.2d)>" % (self.title, self.season, self.index)
+        return "<Episode: %s - %dx%.2d - %s>" % (self.show_title, self.season, self.episode, self.title)
 

--- a/media.py
+++ b/media.py
@@ -18,7 +18,7 @@ class Media(object):
             print "Missing key in element: ", e.message
 
     def __str__(self):
-        return "<Media)>"
+        return "<Media>"
 
     def __repr__(self):
         return "<Media>"

--- a/movie.py
+++ b/movie.py
@@ -13,4 +13,6 @@ class Movie(Video):
     def __repr__(self):
         return "<Movie: %s (%d)>" % (self.title, self.year)
 
+    def __eq__(self, other_movie):
+        return self.__repr__() == other_movie.__repr__()
 

--- a/part.py
+++ b/part.py
@@ -17,7 +17,7 @@ class Part(object):
             print "Missing key in element: ", e.message
 
     def __str__(self):
-        return "<Part)>"
+        return "<Part>"
 
     def __repr__(self):
         return "<Part>"

--- a/show.py
+++ b/show.py
@@ -62,7 +62,7 @@ class Show(object):
 
         prev = None
         for e in reversed(element):
-            if ('viewCount' in e.attrib) and (e.attrib['viewCount'] == '1'):
+            if ('viewCount' in e.attrib) and (e.attrib['viewCount'] >= '1'):
                 if prev == None:
                     return None
                 else:

--- a/video.py
+++ b/video.py
@@ -12,7 +12,8 @@ class Video(object):
         self.summary = element.attrib['summary']
 
         self.viewed = ('viewCount' in element.attrib) and (element.attrib['viewCount'] >= '1')
-        self.offset = int(element.attrib['viewOffset']) if 'viewOffset' in element.attrib else 0
+        self.duration = int(element.attrib['duration']) / 1000 if 'duration' in element.attrib else 0
+        self.offset = int(element.attrib['viewOffset']) / 1000 if 'viewOffset' in element.attrib else 0
 
         self.media = [Media(e, self.server) for e in element.findall('.Media')]
 

--- a/video.py
+++ b/video.py
@@ -21,3 +21,6 @@ class Video(object):
 
     def __repr__(self):
         return "<Video: %s>" % (self.key)
+
+    def __eq__(self, other_video):
+        return self.__repr__() == other_video.__repr__()


### PR DESCRIPTION
getNextUnwatchedEpisode() method would return any episode that (chronologically) comes after an episode with a viewCount 1. This means that if there are three episodes with viewCounts as following, the method will return "Episode 2":
- Episode 1: 1 view
- Episode 2: 2 views
- Episode 3: 0 views 

With proposed changes, this situation is eliminated and "Episode 3" will be correctly returned.
